### PR TITLE
Always show tabs if show_quit_button is set

### DIFF
--- a/kilauncher/tabs.py
+++ b/kilauncher/tabs.py
@@ -50,7 +50,8 @@ class KiLauncherTabs(qtw.QTabWidget):
                     "Please check your configuration file."
                 ))
         # Since tabs are not dynamic, just hide them if there's only one.
-        show_tabbar = len(self.config.tabs_and_launchers) > 1
+        # But always show tabs if show_quit_button=True
+        show_tabbar = (len(self.config.tabs_and_launchers) > 1) or self.config.show_quit_button
         self.tabBar().setVisible(show_tabbar)
 
         # Quit button


### PR DESCRIPTION
Currently if tabs are hidden because there is only one tab, then quit btn is hidden as well....

Obviously another solution would be to move the quit button somewhere else, maybe down to the bottom.